### PR TITLE
Add tests to the Bucket class - some code cleaning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php: 
   - 5.4
   - 5.5
+  - 5.6
 
 before_script:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.5
 
 before_script:
-  - composer install --dev
+  - composer install
 
 script: phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,3 @@ $ git-s3 deploy
 
 ## Support & Contribution
 If you have an issue or an idea how to improve this project please open an Issue/Pull Request [here](https://github.com/schickling/git-s3/issues)
-
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/schickling/git-s3/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/src/GitS3/Console/Commands/DeployCommand.php
+++ b/src/GitS3/Console/Commands/DeployCommand.php
@@ -26,7 +26,7 @@ class DeployCommand extends Command
 		$this->bucket = $application->getBucket();
 		$this->finder = new Finder();
 		$this->finder->ignoreDotFiles(false);
-               $this->finder->ignoreVCS(true);
+		$this->finder->ignoreVCS(true);
 		$this->finder->files()->in($application->getConfig()->getPath());
 
 		if ($this->hasNotBeenInitialized())

--- a/src/GitS3/Wrapper/Bucket.php
+++ b/src/GitS3/Wrapper/Bucket.php
@@ -55,8 +55,8 @@ class Bucket
 		try
 		{
 			$this->client->deleteObject(array(
-				'Bucket' => $this->name,
-				'Key'    => $fileName,
+				'Bucket'	=> $this->name,
+				'Key'		=> $fileName,
 				));
 		}
 		catch(InstanceProfileCredentialsException $e)

--- a/src/GitS3/Wrapper/Bucket.php
+++ b/src/GitS3/Wrapper/Bucket.php
@@ -39,9 +39,9 @@ class Bucket
 		{
 			$this->client->putObject(array(
 				'Bucket'		=> $this->name,
-				'Key'    		=> $file->getRelativePathname(),
-				'SourceFile' 	=> $file->getRealpath(),
-				'ACL'   		=> CannedAcl::PUBLIC_READ,
+				'Key'			=> $file->getRelativePathname(),
+				'SourceFile'		=> $file->getRealpath(),
+				'ACL'			=> CannedAcl::PUBLIC_READ,
 				));
 		}
 		catch(InstanceProfileCredentialsException $e)
@@ -59,7 +59,7 @@ class Bucket
 				'Key'    => $fileName,
 				));
 		}
-		catch(Exception $e)
+		catch(InstanceProfileCredentialsException $e)
 		{
 			throw new InvalidAccessKeyIdException("The AWS Access Key Id you provided does not exist in our records.");
 		}

--- a/src/GitS3/Wrapper/Bucket.php
+++ b/src/GitS3/Wrapper/Bucket.php
@@ -64,4 +64,9 @@ class Bucket
 			throw new InvalidAccessKeyIdException("The AWS Access Key Id you provided does not exist in our records.");
 		}
 	}
+
+	public function setClient($client)
+	{
+		$this->client = $client
+	}
 }

--- a/src/GitS3/Wrapper/Bucket.php
+++ b/src/GitS3/Wrapper/Bucket.php
@@ -67,6 +67,6 @@ class Bucket
 
 	public function setClient($client)
 	{
-		$this->client = $client
+		$this->client = $client;
 	}
 }

--- a/tests/Console/Commands/ConfigCommandTest.php
+++ b/tests/Console/Commands/ConfigCommandTest.php
@@ -11,9 +11,9 @@ class ConfigCommandTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-		$configMock = m::mock('GitS3\Wrapper\Config');
+        $configMock = m::mock('GitS3\Wrapper\Config');
         $configMock->shouldReceive('setKey')->once();
-		$configMock->shouldReceive('setSecret')->once();
+        $configMock->shouldReceive('setSecret')->once();
         $configMock->shouldReceive('setPath')->once();
         $configMock->shouldReceive('setRegion')->once();
         $configMock->shouldReceive('setBucket')->once();
@@ -21,7 +21,7 @@ class ConfigCommandTest extends PHPUnit_Framework_TestCase
 
         $historyMock = m::mock('GitS3\Wrapper\History');
 
-		$application = new Application($configMock, $historyMock);
+        $application = new Application($configMock, $historyMock);
 
         $dialog = m::mock('Symfony\Component\Console\Helper\QuestionHelper')->makePartial();
         $dialog->shouldReceive('ask');
@@ -38,11 +38,11 @@ class ConfigCommandTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
-	public function testCommand()
-	{
+    public function testCommand()
+    {
         // TODO make more interactive
         $this->tester->execute(array('command' => 'config'));
 
         $this->assertRegExp("/^Configuration was successful.$/", $this->tester->getDisplay());
-	}
+    }
 }

--- a/tests/Wrapper/BucketTest.php
+++ b/tests/Wrapper/BucketTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use GitS3\Wrapper\Bucket;
+use GitS3\Wrapper\Config;
+use Aws\S3\S3Client;
+use Aws\S3\Enum\CannedAcl;
+use Aws\S3\Exception\InvalidAccessKeyIdException;
+use Aws\S3\Exception\AccessDeniedException;
+use Aws\Common\Exception\InstanceProfileCredentialsException;
+use Symfony\Component\Finder\SplFileInfo as File;
+
+use Mockery;
+
+class BucketTest extends PHPUnit_Framework_TestCase
+{
+    private $bucket;
+    private $s3Mock;
+    private $config;
+    private $file;
+
+    public function setUp()
+    {
+        $config = __DIR__ . '/resources/config.yml';
+        $this->config = new Config($config);
+           
+        $this->bucket = new Bucket($this->config->getKey(), $this->config->getSecret(), $this->config->getBucket(), $this->config->getRegion());
+        $this->file = new File('something', 'something', 'something');
+        $this->s3Mock = Mockery::mock('Aws\S3\S3Client');
+        $this->bucket->setClient($this->s3Mock);
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+    
+    public function testUpload()
+    {
+        $this->s3Mock->shouldReceive('putObject')->once()->andThrow(new InstanceProfileCredentialsException);
+        $this->setExpectedException(InvalidAccessKeyIdException::class, "The AWS Access Key Id you provided does not exist in our records.");
+        $this->bucket->upload($this->file);
+
+        $this->s3Mock->shouldReceive('putObject')->once()->andThrow(new Aws\S3\Exception\AccessDeniedException);
+        $this->setExpectedException(AccessDeniedException::class);
+        $this->bucket->upload($this->file);
+    }
+
+    public function testDelete()
+    {
+        $this->s3Mock->shouldReceive('deleteObject')->once()->andThrow(new InstanceProfileCredentialsException);
+        $this->setExpectedException(InvalidAccessKeyIdException::class, "The AWS Access Key Id you provided does not exist in our records.");
+        $this->bucket->delete('some/mock/path.sh');
+
+        $this->s3Mock->shouldReceive('deleteObject')->once()->andThrow(new Aws\S3\Exception\AccessDeniedException);
+        $this->setExpectedException(AccessDeniedException::class);
+        $this->bucket->upload($this->file);
+    }
+}

--- a/tests/Wrapper/BucketTest.php
+++ b/tests/Wrapper/BucketTest.php
@@ -9,7 +9,7 @@ use Aws\S3\Exception\AccessDeniedException;
 use Aws\Common\Exception\InstanceProfileCredentialsException;
 use Symfony\Component\Finder\SplFileInfo as File;
 
-use Mockery;
+use Mockery as m;
 
 class BucketTest extends PHPUnit_Framework_TestCase
 {
@@ -25,13 +25,13 @@ class BucketTest extends PHPUnit_Framework_TestCase
            
         $this->bucket = new Bucket($this->config->getKey(), $this->config->getSecret(), $this->config->getBucket(), $this->config->getRegion());
         $this->file = new File('something', 'something', 'something');
-        $this->s3Mock = Mockery::mock('Aws\S3\S3Client');
+        $this->s3Mock = m::mock('Aws\S3\S3Client');
         $this->bucket->setClient($this->s3Mock);
     }
 
     public function tearDown()
     {
-        Mockery::close();
+        m::close();
     }
     
     public function testUpload()

--- a/tests/Wrapper/BucketTest.php
+++ b/tests/Wrapper/BucketTest.php
@@ -37,11 +37,11 @@ class BucketTest extends PHPUnit_Framework_TestCase
     public function testUpload()
     {
         $this->s3Mock->shouldReceive('putObject')->once()->andThrow(new InstanceProfileCredentialsException);
-        $this->setExpectedException(InvalidAccessKeyIdException::class, "The AWS Access Key Id you provided does not exist in our records.");
+        $this->setExpectedException('Aws\S3\Exception\InvalidAccessKeyIdException', "The AWS Access Key Id you provided does not exist in our records.");
         $this->bucket->upload($this->file);
 
         $this->s3Mock->shouldReceive('putObject')->once()->andThrow(new Aws\S3\Exception\AccessDeniedException);
-        $this->setExpectedException(AccessDeniedException::class);
+        $this->setExpectedException('Aws\S3\Exception\AccessDeniedException');
         $this->bucket->upload($this->file);
     }
 

--- a/tests/Wrapper/BucketTest.php
+++ b/tests/Wrapper/BucketTest.php
@@ -48,11 +48,11 @@ class BucketTest extends PHPUnit_Framework_TestCase
     public function testDelete()
     {
         $this->s3Mock->shouldReceive('deleteObject')->once()->andThrow(new InstanceProfileCredentialsException);
-        $this->setExpectedException(InvalidAccessKeyIdException::class, "The AWS Access Key Id you provided does not exist in our records.");
+        $this->setExpectedException('Aws\S3\Exception\InvalidAccessKeyIdException', "The AWS Access Key Id you provided does not exist in our records.");
         $this->bucket->delete('some/mock/path.sh');
 
         $this->s3Mock->shouldReceive('deleteObject')->once()->andThrow(new Aws\S3\Exception\AccessDeniedException);
-        $this->setExpectedException(AccessDeniedException::class);
+        $this->setExpectedException('Aws\S3\Exception\AccessDeniedException');
         $this->bucket->upload($this->file);
     }
 }


### PR DESCRIPTION
* Adds tests/Wrapper/BucketTest.php
* Increases Code Coverage (67% -> 73%)
* Adds 5.6 to .travis.yml
* Removes the --dev flag on Composer due to deprecation
* Narrows exception handling in Bucket.php, in order to prevent other errors from appearing to be from Invalid Access Keys.